### PR TITLE
Updated URL in broker.md

### DIFF
--- a/docs/guide/broker.md
+++ b/docs/guide/broker.md
@@ -31,7 +31,7 @@ curl -O http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key
 sudo apt-key add mosquitto-repo.gpg.key
 rm mosquitto-repo.gpg.key
 cd /etc/apt/sources.list.d/
-sudo curl -O http://repo.mosquitto.org/debian/mosquitto-repo.list
+sudo curl -O http://repo.mosquitto.org/debian/mosquitto-$(awk -F"[)(]+" '/VERSION=/ {print $2}' /etc/os-release).list
 sudo apt-get update
 ```
 


### PR DESCRIPTION
URLs have changed and are dependent on if you are using Wheezy or Jessie.

Subject to discussion as it removes quite a bit of readability. For example we could assume the user is running the latest version and add a note about it.
