### PR TITLE
fix publish path in docs of waypoint~~s~~

### DIFF
--- a/docs/guide/waypoints.md
+++ b/docs/guide/waypoints.md
@@ -10,8 +10,8 @@ contain the elements:
    whether the device is entering or leaving a configured region, respectively.
 
 If you set up a shared waypoint, the app publishes that waypoint (without the retain flag,
-irrespective of your general preference) to the base topic with `/waypoints`
-tacked onto the topic (e.g. `owntracks/<user>/<device>/waypoints`) with the
+irrespective of your general preference) to the base topic with `/waypoint`
+tacked onto the topic (e.g. `owntracks/<user>/<device>/waypoint`) with the
 payload for `_type=waypoint` as specified in the [JSON page](../tech/json.md). For waypoints with disabled sharing, no waypoint message is published. These can be used to note down locations privately. But note that entering or leaving a waypoint will be published as a `location` message as described above.
 
 When you set up a shared waypoint (with a `desc`ription and a `rad`ius), this
@@ -23,7 +23,7 @@ identifier of the waypoint even if it is later modified on the device. For waypo
 
 Subscribers to the broker (our apps and any other program) can avoid getting
 waypoints by subscribing to, say, `owntracks/+/+`; also broker ACLs can
-prohibit access to `owntracks/+/+/waypoints` for particular users if so desired.
+prohibit access to `owntracks/+/+/waypoint` for particular users if so desired.
 Conversely, all messages published by the apps (`location` and `waypoint`) are
 available with a subscription to `owntracks/#`.
 


### PR DESCRIPTION
`owntracks/+/+/waypoint` is what I'm seeing actually get published, so updating docs accordingly