### PR TITLE
Update location monitoring modes documentation

### DIFF
--- a/docs/features/location.md
+++ b/docs/features/location.md
@@ -2,23 +2,7 @@
 
 Location data is obtained by your smartphone and published to the [MQTT broker](../guide/broker.md) as follows:
 
-### Android
-
-The way it currently works is by specifying an interval in which you want to receive updates (the one you configure in the settings). You only receive updates if this amount of time has passed and you moved more than 500m (when the app is in the background. The movement restriction is set to 50m or so when in the foreground).
-
-Say I set an interval of 10min and I don't move; will I get a PUBlish? No. 
-If you move more than 500 meters in 5 minutes you'll get a PUB after 10 minutes. You won't get a PUB after 5 minutes though.
-
-Additional restrictions apply regarding the update intervall. When switching into the background or foreground, a new location request is setup with a different granularity and energy requirement. As a result, a new location is received immedeately by the app. 
-
-Thus, when the app goes into the background, a new location is received. Most likely, this will not result in a publish as the last publish was not longer ago than 10 minutes. Say the last update was exactly 9 minutes ago when the background mode is enabled. In this case no publish will be sent. However, the next location will probably only be received after the specified 10 minutes. At this point, the time of the last publish is longer than 10 minutes ago. So in this worst case, around 20 will pass before a location will be sent. 
-
-If you switch on the app after one minute in the background (11 minutes after the last publish), a new report will be sent immediately as soon as a new location is available. 
-
-
-### iOS 
-
-The iOS app offers 4 modes of location publication:
+The Android and iOS apps offer 4 modes of location publication as well as region monitoring:
 
 * _Quiet_ mode
 * _Manual_ mode
@@ -84,6 +68,22 @@ unmarked (by setting their radius to 0).
 
 Regions are shown on the map display in transparent blue or red circles. Red
 indicates the device is is within the region.
+
+
+### Android
+
+The way it currently works is by specifying an interval in which you want to receive updates (the one you configure in the settings). You only receive updates if this amount of time has passed and you moved more than 500m (when the app is in the background. The movement restriction is set to 50m or so when in the foreground).
+
+Say I set an interval of 10min and I don't move; will I get a PUBlish? No. 
+If you move more than 500 meters in 5 minutes you'll get a PUB after 10 minutes. You won't get a PUB after 5 minutes though.
+
+Additional restrictions apply regarding the update intervall. When switching into the background or foreground, a new location request is setup with a different granularity and energy requirement. As a result, a new location is received immedeately by the app. 
+
+Thus, when the app goes into the background, a new location is received. Most likely, this will not result in a publish as the last publish was not longer ago than 10 minutes. Say the last update was exactly 9 minutes ago when the background mode is enabled. In this case no publish will be sent. However, the next location will probably only be received after the specified 10 minutes. At this point, the time of the last publish is longer than 10 minutes ago. So in this worst case, around 20 will pass before a location will be sent. 
+
+If you switch on the app after one minute in the background (11 minutes after the last publish), a new report will be sent immediately as soon as a new location is available. 
+
+### iOS 
 
 #### iBeacon monitoring
 


### PR DESCRIPTION
Make location monitoring modes documentation common to both the Android and iOS app. List OS specific location documentation (e.g., iBeacons) in that section.