### PR TITLE
Explain how to use HTTP mode with recorder.

### DIFF
--- a/docs/tech/http.md
+++ b/docs/tech/http.md
@@ -8,13 +8,19 @@ The URL you enter in the setting for HTTP mode has the following syntax:
 http[s]://[user[:password]@]host[:port]/path
 ```
 
-Authentication to the endpoint is performed with HTTP Basic authentication and, as such, we very strongly recommend the use of TLS (`https://` scheme).
+Authentication to the endpoint is performed with HTTP Basic authentication and, as such, we very strongly recommend the use of TLS (`https://` scheme). The [encryption](../features/encrypt.md) feature is supported, and you can use it with HTTP endpoints; the Owntracks Recorder supports decryption, but if you implement your own endpoint you have to perform decryption at the endpoint yourself.
+
+The Recorder supports [HTTP mode](https://github.com/owntracks/recorder#http-mode) out of the box at the `/pub` end point, as long as it is built with HTTP support and a `--http-port` is configured. When using Recorder in this mode, set the URL to:
+
+```
+http[s]://recorder_host[:port]/pub
+```
+
+The username and password for HTTP Basic authentication can be configured in application settings, under *Identification*. Device name and tracker name can also be configured there. Username and device name are *required* when using the Recorder. Parameters for _username_ and _devicename_ can also be included in the URL (`?u=user&d=device`), or alternatively using the `X-Limit-U` and `X-Limit-D` headers respectively. You can also force _username_ using a proxy as described in the Recorder's documentation.
 
 All publishes which are currently done with MQTT will then be POSTed to the endpoint with exactly the same [JSON](json.md) payload formats. Support for Friends is available if your HTTP endpoint can produce appropriate data which is consumed by the app whenever it POSTs a location. This differs greatly from MQTT mode wherein the app subscribes to topics and is informed of data on those topics whenever it's available; in HTTP mode the apps do not periodically poll your HTTP endpoint; rather it is contacted only when the app is ready to publish its location or when you manually trigger a publish. (Support for friends and optionally their cards is implemented in the Recorder.)
 
 If the HTTP endpoint is reachable (no exception, no timeout, DNS name exists, etc.) and a successfull return code (`2xx`) is returned  the payload is considered POSTed. In the event that the endpoint is unreachable, the payload will be queued and posted at a later time.
-
-The [encryption](../features/encrypt.md) feature is supported, and you can use it with HTTP endpoints; the Recorder supports decryption, but if you implement your own endpoint you have to perform decryption at the endpoint yourself.
 
 If the HTTP endpoint returns a status code 200 it will typically return an empty JSON payload array `[]`. It may, however, return an array of JSON objects to the OwnTracks device, each of which must be a valid `_type` as described in [JSON](../tech/json.md). Support for the following `_type` is implemented:
 
@@ -24,9 +30,6 @@ If the HTTP endpoint returns a status code 200 it will typically return an empty
 | `cmd`        | Y     | Y    | with `action` set to `dump`, `reportLocation`, `reportSteps`, `action`, and `setWaypoints`
 | `card`       | Y     | Y    | Can return [card](../features/card.md) objects for self and friends
 | `transition` | Y     | Y    | Obtain friends' transition events.
-
-The OwnTracks Recorder supports [HTTP mode](https://github.com/owntracks/recorder#http-mode) out of the box, as long as it is built with HTTP support and a `--http-port` is configured.
-When using the Recorder, the URL you specify in the app's configuration *must* include parameters for _username_ and _devicename_ (`?u=user&d=device`), alternatively using the `X-Limit-U` and `X-Limit-D` headers respectively. You can also force _username_ using a proxy as described in the Recorder's documentation.
 
 ### Distinguishing payloads
 


### PR DESCRIPTION
Clarify that the /pub end point should be used if Recorder is being used in HTTP mode. Also combine paragraphs discussing authentication and encryption.