### PR TITLE
Fix units of lat and long

### DIFF
--- a/docs/tech/json.md
+++ b/docs/tech/json.md
@@ -52,8 +52,8 @@ This location object describes the location of the device that reported it.
 * `batt` Device battery level _(iOS,Android/integer/percent/optional)_
 * `bs` Battery Status 0=unknown, 1=unplugged, 2=charging, 3=full  _(iOS)_
 * `cog` Course over ground _(iOS/integer/degree/optional)_
-* `lat` latitude _(iOS,Android/float/meters/required)_
-* `lon` longitude _(iOS,Android/float/meters/required)_
+* `lat` latitude _(iOS,Android/float/degree/required)_
+* `lon` longitude _(iOS,Android/float/degree/required)_
 * `rad` radius around the region when entering/leaving _(iOS/integer/meters/optional)_
 * `t` trigger for the location report _(iOS,Android/string/optional)_
     * `p` ping issued randomly by background task _(iOS,Android)_


### PR DESCRIPTION
Hi,
the JSON documentation indicates the `lat` and `long` fields giving latitude and longitude in meters, which doesn't make sense and does (at least for my android app) in fact report latitude and longitude in degrees. This commit contains this little fix. Feel free to accept or reject it.

Cheers,
Volker