### PR TITLE
Set correct repo_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: OwnTracks Booklet
 site_url: http://owntracks.org
 site_author: OwnTracks.org
-repo_url: https://github.com/owntracks
+repo_url: https://github.com/owntracks/booklet
 site_dir: _site
 nav:
 - Intro: 'index.md'


### PR DESCRIPTION
The `repo_url` wasn't pointing to this repo, which meant that the `Edit on GitHub` links in the top right corner of every page just sent you to a 404 page. This change fixes that.

It also means that other links, such as the `GitHub` link in the bottom left corner of the theme now points to this specific repo instead of the general "OwnTracks" group. I don't know if you actually wanted that link to point to the general group, but in that case you will have to edit something in the theme to allow for two separate base URLs depending on the link context.