### PR TITLE
Region: Add unit used for radius

### DIFF
--- a/docs/guide/waypoints.md
+++ b/docs/guide/waypoints.md
@@ -4,7 +4,7 @@
 If you've configured a geo-fence, a `location` message will
 contain the elements:
 
-* `rad`ius (if its value is greater than 0)
+* `rad`ius (if its value is greater than 0): unit: meters
 * `desc`ription with the name you set for the waypoint
 * `event` with a value of `"enter"` or `"leave"`, depending on
    whether the device is entering or leaving a configured region, respectively.


### PR DESCRIPTION
Add the unit that is used for the radius when defining a region. As far as I can see, this is nowhere defined. To me, it is not self-explanatory that the unit is meters. It could also be something like kilometers, miles, or feet.