### PR TITLE
card message should contain tid

### DIFF
--- a/docs/tech/json.md
+++ b/docs/tech/json.md
@@ -406,6 +406,7 @@ Apps read [Card](../features/card.md) to display a name and icon for a user.
 }
 ```
 
+* `tid` Tracker ID to associate the card with _(iOS,Android/string/required)_
 * `name` Name to identify a user _(iOS,Android/string/optional)_
 * `face` Base64 encoded PNG image that is displayed instead of the Tracker ID _(iOS,Android/string/optional)_
 


### PR DESCRIPTION
Card messages should contain a `tid` field, specifying the tracker ID to associate the card with.

(Card messages without a `tid` field are still accepted (at least on Android), but seem to always resolve to a tracker ID of `ll` and an identifier/topic of `owntracks/http/null`.)

This was mentioned in owntracks/talk#44, but never ended up in the docs.