### PR TITLE
created_at timestamp is conditionally included

### DIFF
--- a/docs/tech/json.md
+++ b/docs/tech/json.md
@@ -86,7 +86,7 @@ This location object describes the location of the device that reported it.
 * `inrids` contains a list of region IDs the device is currently in (e.g. `["6da9cf","3defa7"]`). Might be empty. _(iOS,Android/list of strings/optional)_
 * `SSID`, if available, is the unique name of the WLAN. _(iOS,string/optional)_
 * `BSSID`, if available, identifies the access point. _(iOS,string/optional)_
-* `created_at` identifies the time at which the message is constructed (vs. `tst` which is the timestamp of the GPS fix) _(iOS,Android)_
+* `created_at` identifies the time at which the message is constructed (if it differs from `tst`, which is the timestamp of the GPS fix) _(iOS,Android/integer/epoch/optional)_
 * `m` identifies the monitoring mode at which the message is constructed (_significant_=`1`, _move_=`2`)  _(iOS/integer/optional)_
 * `_id` random identifier to be used by consumers to correlate & distinguish send/return messages _(Android/string)_
 


### PR DESCRIPTION
As per [the comment on owntracks/booklet#157](https://github.com/owntracks/talk/issues/157#issuecomment-1495875188), the created_at timestamp is only included if it differs from the tst GPS fix timestamp.

(I haven't personally observed it being omitted yet, but did find the linked comment while perusing the talk repo. I assume this is still the case, for both iOS and Android.)