### PR TITLE
Fix typos and puctuation in faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,12 +1,12 @@
 ## Answers
 
-This is a list of question we really get asked a lot and some answers to these questions.
+This is a list of questions we really get asked a lot and some answers to these questions.
 
 Q: Can I have OwnTracks not publish location for a specific period of time?<br/>
 A: Set mode to manual (iOS) or disable automatic location reporting (Android)
 
 Q: How can I restart OwnTracks?<br/>
-A: Swip away and start (iOS), Force close and start (Android)
+A: Swipe away and start (iOS), Force close and start (Android)
 
 Q: Can you remove Google Play Services from the Android app? <br/>
 A: No
@@ -15,11 +15,11 @@ Q: Can you remove Google Maps from the Android app? <br/>
 A: No
 
 Q: Since updating to Android 6 (or higher), background location reporting does not work as before<br/>
-A: Since Android 6 Google has startet to restrict background apps. We're doing our best to work agains this were we can. 
-Your best bet is to enable the ongoing notifications which enables some background features. HTTP mode works best in the background because it can rely on the OS background scheduling in contrast to MQTT mode which requires a persistent TCP connection. 
+A: Since Android 6 Google has started to restrict background apps. We're doing our best to work against this were we can. 
+Your best bet is to enable the ongoing notifications, which enable some background features. HTTP mode works best in the background because it can rely on the OS background scheduling, in contrast to MQTT mode, which requires a persistent TCP connection. 
 
 Q: I've moved, but OwnTracks is not reporting my location<br/>
-A: Depending on the mode the apps report location changes only after significant changes. 
+A: Depending on the mode, the apps report location changes only after significant changes. 
 
 Q: How do I enable region monitoring? (Waypoints)<br/>
 
@@ -29,9 +29,9 @@ Q: Why are transition events delayed?<br/>
 
 Q: How can I increase reporting frequency and does that have any negative impact?<br/>
 
-A: I have a question<br/>
+Q: I have a question<br/>
 A: We love questions. Well, sometimes. If you want to ask us a question or desire feedback from other OwnTracks users, visit us at the [OwnTracks meta tracker](https://github.com/owntracks/talk).
 
 Q: How can I report an issue?<br/>
-A: If you think you've found a bug, please report it on our respective [android](https://github.com/owntracks/android) or [ios](https://github.com/owntracks/ios) issue tracker on Github. 
+A: If you think you've found a bug, please report it on our respective [Android](https://github.com/owntracks/android) or [iOS](https://github.com/owntracks/ios) issue tracker on Github. 
 


### PR DESCRIPTION
There were a few small, distracting issues in the doc. This patch fixes them.